### PR TITLE
fix(excalidraw): patch tunnel-rat to prevent white screen on Electron

### DIFF
--- a/.changeset/fix-tunnel-rat-infinite-loop.md
+++ b/.changeset/fix-tunnel-rat-infinite-loop.md
@@ -4,5 +4,4 @@
 
 Fix white screen caused by tunnel-rat infinite update loop on Electron (ZERO-9972)
 
-Patch tunnel-rat's useLayoutEffect cleanup to defer zustand set() via queueMicrotask,
-preventing cascading re-renders when multiple tunnel instances unmount simultaneously.
+Patch tunnel-rat's useLayoutEffect cleanup to defer zustand set() via queueMicrotask, preventing cascading re-renders when multiple tunnel instances unmount simultaneously.

--- a/.changeset/fix-tunnel-rat-infinite-loop.md
+++ b/.changeset/fix-tunnel-rat-infinite-loop.md
@@ -1,0 +1,8 @@
+---
+"@oviceinc/excalidraw": patch
+---
+
+Fix white screen caused by tunnel-rat infinite update loop on Electron (ZERO-9972)
+
+Patch tunnel-rat's useLayoutEffect cleanup to defer zustand set() via queueMicrotask,
+preventing cascading re-renders when multiple tunnel instances unmount simultaneously.

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@
 .idea
 .vercel
 .vscode
-.yarn
+.yarn/*
+!.yarn/patches
 *.log
 *.tgz
 build

--- a/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch
+++ b/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch
@@ -1,0 +1,68 @@
+diff --git a/dist/index.cjs.js b/dist/index.cjs.js
+index ba8032c7a3c9fb8d606dba81f25455fedbdf0a08..935cc9f007cca26283414f943384919371e49a03 100644
+--- a/dist/index.cjs.js
++++ b/dist/index.cjs.js
+@@ -51,11 +51,13 @@ function tunnel() {
+         }) => ({
+           current: [...current, children]
+         }));
+-        return () => set(({
+-          current
+-        }) => ({
+-          current: current.filter(c => c !== children)
+-        }));
++        return () => {
++          queueMicrotask(() => set(({
++            current
++          }) => ({
++            current: current.filter(c => c !== children)
++          })));
++        };
+       }, [children, version]);
+       return null;
+     },
+diff --git a/dist/index.js b/dist/index.js
+index 3c23492235b73c6608ac1efbbd0fdff695689ed0..cef6339fc49bb86c58a9d1e885283477f71abff4 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -45,11 +45,13 @@ function tunnel() {
+         }) => ({
+           current: [...current, children]
+         }));
+-        return () => set(({
+-          current
+-        }) => ({
+-          current: current.filter(c => c !== children)
+-        }));
++        return () => {
++          queueMicrotask(() => set(({
++            current
++          }) => ({
++            current: current.filter(c => c !== children)
++          })));
++        };
+       }, [children, version]);
+       return null;
+     },
+diff --git a/src/index.tsx b/src/index.tsx
+index 1f0f6c1093ca3a287a0612c13e51fcc61329cd09..d2bd3928d8e16000ca51ffdf881127a86bd1de6d 100644
+--- a/src/index.tsx
++++ b/src/index.tsx
+@@ -39,10 +39,13 @@ export default function tunnel() {
+           current: [...current, children],
+         }))
+ 
+-        return () =>
+-          set(({ current }) => ({
+-            current: current.filter((c) => c !== children),
+-          }))
++        return () => {
++          queueMicrotask(() =>
++            set(({ current }) => ({
++              current: current.filter((c) => c !== children),
++            }))
++          )
++        }
+       }, [children, version])
+ 
+       return null

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -84,7 +84,7 @@
     "pwacompat": "2.0.17",
     "roughjs": "4.6.4",
     "sass": "1.51.0",
-    "tunnel-rat": "0.1.2"
+    "tunnel-rat": "patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch"
   },
   "devDependencies": {
     "@babel/core": "7.24.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,7 @@ __metadata:
     size-limit: "npm:9.0.0"
     style-loader: "npm:3.3.3"
     ts-loader: "npm:9.3.1"
-    tunnel-rat: "npm:0.1.2"
+    tunnel-rat: "patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch"
     typescript: "npm:4.9.4"
     vite: "npm:5.0.12"
   peerDependencies:
@@ -13315,6 +13315,15 @@ __metadata:
   dependencies:
     zustand: "npm:^4.3.2"
   checksum: 10c0/93cd50c7c9141e2662707602a21401145092e5a3c815b57a752937419ab6187a2ff36fa7e0f65e0c587022149bf2d323ace07dff61106511b7d4845e53390cc9
+  languageName: node
+  linkType: hard
+
+"tunnel-rat@patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch":
+  version: 0.1.2
+  resolution: "tunnel-rat@patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch::version=0.1.2&hash=730df7"
+  dependencies:
+    zustand: "npm:^4.3.2"
+  checksum: 10c0/6a8ee6202980ef42ceec04f0cc9f6f64b17fec65474883f663e8f93fb9c5d46159938cf29620f2b814eb957ead922ea7130471fed6887d6398272ec74af4c82d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Patch `tunnel-rat` (v0.1.2) to defer `useLayoutEffect` cleanup `set()` via `queueMicrotask`, preventing "Maximum update depth exceeded" crash on Electron
- During Excalidraw unmount, 9 tunnel instances unmount simultaneously, causing a cascading synchronous state update loop that exceeds React's 50-update limit
- Browsers are unaffected because page navigation destroys the V8 context; Electron's SPA context stays alive during workspace leave, allowing the infinite loop to manifest

## Changes

- **`.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch`**: Wraps cleanup `set()` in `queueMicrotask()` (applied to `src/index.tsx`, `dist/index.js`, `dist/index.cjs.js`)
- **`packages/excalidraw/package.json`**: Point `tunnel-rat` to patched version via `yarn patch`
- **`.gitignore`**: Track `.yarn/patches/` directory

## Why `queueMicrotask`

- Executes **after** React's commit phase completes → `Out` re-render is no longer a nested update
- Runs **before** the next paint → no visual impact
- `setTimeout(fn, 0)` would run after paint and could cause flicker

## Verification

1. **Electron**: Open Excalidraw whiteboard or screen sharing edit mode, then leave workspace → no white screen
2. **Electron**: Rapidly open/close whiteboard → no "Maximum update depth exceeded" error
3. **Browser**: Confirm Excalidraw still works correctly

## References

- Linear: [ZERO-9972](https://linear.app/ovice/issue/ZERO-9972)
- Sentry: [OVICE-UI-15FN](https://ovice.sentry.io/issues/OVICE-UI-15FN)