### PR TITLE
fix(excalidraw): move tunnel-rat patch to root resolutions for publish compatibility

### DIFF
--- a/.changeset/fix-tunnel-rat-publish.md
+++ b/.changeset/fix-tunnel-rat-publish.md
@@ -1,0 +1,5 @@
+---
+"@oviceinc/excalidraw": patch
+---
+
+Move tunnel-rat patch reference from package dependencies to monorepo root resolutions so consumers can resolve the dependency normally.

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   },
   "resolutions": {
     "@types/react": "18.2.0",
-    "strip-ansi": "6.0.1"
+    "strip-ansi": "6.0.1",
+    "tunnel-rat": "patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch"
   }
 }

--- a/packages/excalidraw/package.json
+++ b/packages/excalidraw/package.json
@@ -84,7 +84,7 @@
     "pwacompat": "2.0.17",
     "roughjs": "4.6.4",
     "sass": "1.51.0",
-    "tunnel-rat": "patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch"
+    "tunnel-rat": "0.1.2"
   },
   "devDependencies": {
     "@babel/core": "7.24.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3022,7 +3022,7 @@ __metadata:
     size-limit: "npm:9.0.0"
     style-loader: "npm:3.3.3"
     ts-loader: "npm:9.3.1"
-    tunnel-rat: "patch:tunnel-rat@npm%3A0.1.2#~/.yarn/patches/tunnel-rat-npm-0.1.2-69bf8f367e.patch"
+    tunnel-rat: "npm:0.1.2"
     typescript: "npm:4.9.4"
     vite: "npm:5.0.12"
   peerDependencies:


### PR DESCRIPTION
## Summary

- Move `tunnel-rat` patch reference from `packages/excalidraw/package.json` dependencies to monorepo root `resolutions`
- Fixes consumers (ovice-ui) failing to resolve `patch:tunnel-rat@...` when installing `@oviceinc/excalidraw@0.17.28`

## Problem

The `patch:` protocol in `dependencies` was published as-is to GitHub Packages. Consumers don't have the `.yarn/patches/` file, causing `ENOENT` during `yarn install`.

## Fix

| File | Change |
|------|--------|
| `packages/excalidraw/package.json` | `"tunnel-rat": "0.1.2"` (plain version for consumers) |
| `package.json` (root) | `resolutions` with patch reference (local dev still uses patched version) |

The actual fix is already bundled in `dist/node_modules/tunnel-rat/`, so consumers get the patched code regardless of what yarn resolves.

## References

- Linear: [ZERO-9972](https://linear.app/ovice/issue/ZERO-9972)
- Previous PR: #61